### PR TITLE
Fix syntax error in example.

### DIFF
--- a/README.md
+++ b/README.md
@@ -26,7 +26,7 @@ var (
 )
 
 func main() {
-	ctx := context.Background(),
+	ctx := context.Background()
 
 	client, err := bluesky.Dial(ctx, bluesky.ServerBskySocial)
 	if err != nil {


### PR DESCRIPTION
Just removing the stray comma from the example.